### PR TITLE
Ops: Adds coveralls support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   python: circleci/python@1.1.0
-#  codecov: codecov/codecov@1.0.2
+  codecov: codecov/codecov@1.0.2
 
 jobs:
   build-and-test:
@@ -23,8 +23,8 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: reports
-#      - codecov/upload:
-#          file: 0/reports/junit.xml
+      - codecov/upload:
+          file: 0/reports/junit.xml
 
 workflows:
   main:

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .idea
 
 node_modules
+test-reports

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/ACWIC/employer-admin/branch/master/graph/badge.svg?token=YB6L7D2H70)](https://codecov.io/gh/ACWIC/employer-admin)
+
 # Aged Care Provider Admin API
 
 This is a FastAPI app that is built to run on AWS Lambda via the API Gateway.


### PR DESCRIPTION
Coveralls required a more complex setup flow, since the repo is still private.

I opted for the simpler solution, and went with codecov for now.

We can absolutely switch later if we need