### PR TITLE
docs: update readme with pre-commit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,22 @@ Tests are run with pytest, which can be executed with the shortcut make command:
 make test
 ```
 
-TODO: include pre-commit checks in make-test
-
-
 ## Style guide
-We use pre-commit hooks, including black, isort, flake8.
+We follow the guidelines offered by black, isort, and flake8
 
-The suggested way to install these hooks it is by installing [pre-commit](https://pre-commit.com/), 
+### pre-commit
+We use pre-commit to enforce style checks before committing code in git.
 
-then running 
-`pre-commit install`
+Please install it from [pre-commit](https://pre-commit.com/)
+then run `pre-commit install`
 
 Note that on the first time you run `git commit`, it's gonna take sometime 
 to install all the hooks, but after that it will be fast.
+
+to check your code style without having to do `git commit`, run:
+ 
+ `pre-commit run`: It will check your staged files, and print any issues
+ 
+ `pre-commit run -a`: It will check all the project files
+ 
+ 


### PR DESCRIPTION
I added an explanation for the `pre-commit` commands specifically `pre-commit run` and `pre-commit run -a`.

These should replace the `TODO` mentioning add style checks to `make test`. 
