### PR TITLE
Ops: Adds .editorconfig file to standardize our environments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 79
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
There's lots of simple styling guidelines that your editor can save you the hassle of always fixing them after you run into a pre-commit issue. 
this `.editorconfig` file is the new configuration standard for most editors, and come natively with some as well.

Check the website to know if integrates out-of-the-box with your editor/IDE or you need to install a plugin.

https://editorconfig.org/

One example is the empty line at end-of-file, with this config, once your editor sees the file, it will append an empty line automatically. 
Probably you already have a tool for that, but the goal here is to standardize as much as we can of the workflow, as this is an open-source project (at the end).