### PR TITLE
Ops: report deployment status to slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   codecov: codecov/codecov@1.0.2
   flake8: arrai/flake8@6.0.0
   aws-cli: circleci/aws-cli@1.3.0
+  slack: circleci/slack@4.0.2
 
 jobs:
   build-and-test:
@@ -54,6 +55,12 @@ jobs:
       - aws-cli/setup
       - run:
           command: make deploy_lambda STAGE=dev
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
 
   deploy-to-prod:
     executor: aws-cli/default
@@ -62,6 +69,12 @@ jobs:
       - aws-cli/setup
       - run:
           command: make deploy_lambda STAGE=prod
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
 workflows:
   main:
     jobs:
@@ -74,9 +87,13 @@ workflows:
           filters:
             branches:
               only: main
+          context:
+            - slack-secrets
       - deploy-to-prod:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v.*-stable/
+          context:
+            - slack-secrets


### PR DESCRIPTION
Sending notification to slack when there's a successful deployment to either dev or prod

Also, fixes a problem that we had with deploying to prod. The code has an implicit rule to deploy to prod when there's a matching tag, or (on any branch!)